### PR TITLE
Switch to 'apt' for package management and remove unnecessary 'sudo'

### DIFF
--- a/Linux-Labs/102-monitoring-linux-logs/step1/text.md
+++ b/Linux-Labs/102-monitoring-linux-logs/step1/text.md
@@ -13,11 +13,11 @@ Refer to the [Grafana Docs](https://grafana.com/docs/grafana/latest/setup-grafan
 Install the required packages and Grafana GPG key.
 
 ```plain
-sudo apt-get install -y apt-transport-https
+apt install -y apt-transport-https
 ```{{exec}}
 
 ```plain
-sudo apt-get install -y software-properties-common wget
+apt install -y software-properties-common wget
 ```{{exec}}
 
 ```plain
@@ -33,9 +33,9 @@ echo "deb [signed-by=/usr/share/keyrings/grafana.key] https://apt.grafana.com st
 Finally, we're ready to install Grafana:
   
 ```plain
-sudo apt-get update
+apt update
 # Install the latest Enterprise release:
-sudo apt-get install -y grafana-enterprise
+apt install -y grafana-enterprise
 ```{{exec}}
 
 Now that you've installed Grafana, let's make sure it's started.

--- a/Linux-Labs/103-monitoring-linux-telemetry/step1/text.md
+++ b/Linux-Labs/103-monitoring-linux-telemetry/step1/text.md
@@ -13,11 +13,11 @@ Refer to the [Grafana Docs](https://grafana.com/docs/grafana/latest/setup-grafan
 Install the required packages and Grafana GPG key.
 
 ```plain
-sudo apt-get install -y apt-transport-https
+apt install -y apt-transport-https
 ```{{exec}}
 
 ```plain
-sudo apt-get install -y software-properties-common wget
+apt install -y software-properties-common wget
 ```{{exec}}
 
 ```plain
@@ -33,9 +33,9 @@ echo "deb [signed-by=/usr/share/keyrings/grafana.key] https://apt.grafana.com st
 Finally, we're ready to install Grafana:
   
 ```plain
-sudo apt-get update
+apt update
 # Install the latest Enterprise release:
-sudo apt-get install -y grafana-enterprise
+apt install -y grafana-enterprise
 ```{{exec}}
 
 Now that you've installed Grafana, let's make sure it's started.

--- a/Linux-Labs/104-monitoring-linux-Influx-Grafana/step1/text.md
+++ b/Linux-Labs/104-monitoring-linux-Influx-Grafana/step1/text.md
@@ -13,11 +13,11 @@ Refer to the [Grafana Docs](https://grafana.com/docs/grafana/latest/setup-grafan
 Install the required packages and Grafana GPG key.
 
 ```plain
-sudo apt-get install -y apt-transport-https
+apt install -y apt-transport-https
 ```{{exec}}
 
 ```plain
-sudo apt-get install -y software-properties-common wget
+apt install -y software-properties-common wget
 ```{{exec}}
 
 ```plain
@@ -33,9 +33,9 @@ echo "deb [signed-by=/usr/share/keyrings/grafana.key] https://apt.grafana.com st
 Finally, we're ready to install Grafana:
   
 ```plain
-sudo apt-get update
+apt update
 # Install the latest Enterprise release:
-sudo apt-get install -y grafana-enterprise
+apt install -y grafana-enterprise
 ```{{exec}}
 
 Now that you've installed Grafana, let's make sure it's started.


### PR DESCRIPTION
Updated package management to use `apt` instead of `apt-get`. `apt` is update version of `apt-get`.
Removed unnecessary `sudo` from the commands as the **killercoda** user already has root access. Since **killercoda** already has root access, there is no need for elevated privileges when executing the commands.