### PR TITLE
mysql-deploy-in-kubernetes: storage unit accuracy

### DIFF
--- a/Kubernetes-Labs/mysql-deploy-in-kubernetes/step1/text.md
+++ b/Kubernetes-Labs/mysql-deploy-in-kubernetes/step1/text.md
@@ -1,6 +1,6 @@
 Your organization is going to start building out three tier apps. You know that mysql can act as a backend to that architecture. You decided to deploy mysql into a Kubernetes cluster.
 
-Create a PV and PVC to store your mysql data. Make sure it is at least 10 GB.
+Create a PV and PVC to store your mysql data. Make sure it is at least 10 GiB.
 
 
 

--- a/Kubernetes-Labs/mysql-deploy-in-kubernetes/step2/text.md
+++ b/Kubernetes-Labs/mysql-deploy-in-kubernetes/step2/text.md
@@ -1,4 +1,4 @@
-Create a service that exposes the mysql pod to the internal cluster on port 3306. Name it mysql-service
+Create a service that exposes the mysql pod to the internal cluster on port 3306. Name it mysql-service.
 
 Create a deployment that runs a mysql pod that is listening on port 3306. Ensure that the resources come up correctly.
 


### PR DESCRIPTION
Minor nitpick. 
Solutions file is Gibibytes (the actual Kubernetes manifest) while the text is in Gigabytes. 
Just editing for consistency / clarification.