### PR TITLE
Cleaned up the trailing ':' with sed.

### DIFF
--- a/Linux-Labs/04-checking-networking-and-ports/step1/text.md
+++ b/Linux-Labs/04-checking-networking-and-ports/step1/text.md
@@ -1,5 +1,3 @@
-You are a new system administrator at a company. You've been tasked with finding out information about a set of servers that has very little to no documentation on it.
-
 Check network information.
 
 Put the name of your network interface into a file called /root/interface.
@@ -22,13 +20,13 @@ ip addr
 What is the name of your interface? 
 
 ```plain
-ip addr | grep enp | grep mtu | awk '{print $2}'
+ip addr | grep enp | grep mtu | awk '{print $2}' | sed 's/://'
 ```{{exec}}
 
 Put that value in a file /root/interface.
 
 ```plain
-ip addr | grep enp | grep mtu | awk '{print $2}' > /root/interface
+ip addr | grep enp | grep mtu | awk '{print $2}' | sed 's/://' > /root/interface
 ```{{exec}}
 
 There are other ways to do this, but this will do it with one command.

--- a/Linux-Labs/04-checking-networking-and-ports/step1/text.md
+++ b/Linux-Labs/04-checking-networking-and-ports/step1/text.md
@@ -1,3 +1,5 @@
+You are a new system administrator at a company. You've been tasked with finding out information about a set of servers that has very little to no documentation on it.
+
 Check network information.
 
 Put the name of your network interface into a file called /root/interface.


### PR DESCRIPTION
#  Introduce sed(stream editor)

- It's a small change but I think it can add a little value to the lab and make the ouput of the commands that are supposed to return the name of the interface prettier(there is a trailing :).

### Before:

```plain
ip addr | grep enp | grep mtu | awk '{print $2}'
enp1s0:
```

### After:
```plain
ip addr | grep enp | grep mtu | awk '{print $2}' | sed 's/://'
enp1s0
```


- In my experience using *sed* to manipulate text is both powerful and useful. As a predicesor of *vi/vim* I think it's  an introduction to *vi/vim* as the same commands can be ran from *vi/vim* in command mode.