### PR TITLE
fix(verify): Update cksum to match local user's cksum

### DIFF
--- a/Linux-Labs/05-ssh-and-scp/step2/verify.sh
+++ b/Linux-Labs/05-ssh-and-scp/step2/verify.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-cksum /tmp/node01.crontab | grep 638366506
+ORIGINAL=$(ssh node01 'cksum /etc/crontab' | awk '{print $1}')
+cksum /tmp/node01.crontab | grep $ORIGINAL


### PR DESCRIPTION
The 1st part of the lab is fine, the 2nd part of the lab fails to validate. 
I found the cause: the `cksum` output in my terminal instance did not match the hard-coded validation check in `verify.sh`.

Fixed the hard-coded output of cksum for `node01:/etc/crontab` to account for changing `cksum` outputs on different terminal instances. 
