### PR TITLE
Update step 2 solution with non-deprecated action from ~ to stop statement

### DIFF
--- a/Linux-Labs/206-setting-up-rsyslog/step2/text.md
+++ b/Linux-Labs/206-setting-up-rsyslog/step2/text.md
@@ -23,7 +23,7 @@ Add the following lines to your new file.
 ```plain
 $template RemoteLogs,"/var/log/%HOSTNAME%/messages.log"
 if ($fromhost-ip != "127.0.0.1") then ?RemoteLogs
-&~
+& stop
 ```
 
 Restart the rsyslog service on controlplane


### PR DESCRIPTION
When setting up the log filter, the solution suggests a deprecated action, namely with `&~`.
This results in the following warning message (also referenced in [rsyslog compatibility docs](https://www.rsyslog.com/doc/compatibility/v7compatibility.html#omruleset-and-discard-action-are-deprecated)):
```
rsyslogd[20549]: warning: ~ action is deprecated, consider using the 'stop' statement instead
```
Considering that the version of rsyslog running in the Killercoda environment is `8.2001.0` -- and for the sake of future proofing -- applied the proposed changing swapping `~` to `stop`. Testing in the lab environment shows no unintended consequences and the warning goes away.