### PR TITLE
Fix minor formatting errors with finish.md in two linux security labs

### DIFF
--- a/Linux-Labs/205-setting-up-uncomplicated-firewall-UFW/finish.md
+++ b/Linux-Labs/205-setting-up-uncomplicated-firewall-UFW/finish.md
@@ -1,2 +1,2 @@
-Look at you, learning Linux Security
+Look at you, learning Linux Security!
 You set up a firewall and opened the necessary ports to allow traffic into your server securely.

--- a/Linux-Labs/206-setting-up-rsyslog/finish.md
+++ b/Linux-Labs/206-setting-up-rsyslog/finish.md
@@ -1,4 +1,4 @@
-Look at you, learning Linux Security
+Look at you, learning Linux Security!
 You set up system logging and were able to see data flow from node01 into controlplane for centralized logging.
 
 Check https://attack.mitre.org/techniques/T1070/ for more information about why we want to track logs in real time.


### PR DESCRIPTION
Two of the Linux security labs have a formatting issue in the "finishing up" step. See screenshot below for example.

![image](https://github.com/user-attachments/assets/ea8ed88b-709c-4e55-b9d3-0e9e59c9fe98)

PR fixes the two labs and makes it match the style applied in the other security labs, such as with the [chroot jail lab](https://github.com/het-tanis/prolug-labs/blob/main/Linux-Labs/204-building-a-chroot-jail/finish.md?plain=1).