### PR TITLE
fix: Add creation for nonexistent /etc/sysconfig

### DIFF
--- a/Linux-Labs/103-monitoring-linux-telemetry/step2/text.md
+++ b/Linux-Labs/103-monitoring-linux-telemetry/step2/text.md
@@ -47,6 +47,7 @@ Copy the sysconfig settings from config_files and the binary for node_explorer a
 
 ```
 cp node_exporter /usr/sbin/
+mkdir /etc/sysconfig
 cp /opt/node_exporter/node_exporter-*.*-amd64/config_files/examples/systemd/sysconfig.node_exporter /etc/sysconfig/node_exporter
 ```{{exec}}
 


### PR DESCRIPTION
The command that copies the sysconfig for node_exporter fails. On checking, the system doesn't have an `/etc/sysconfig` directory by default. I added a `mkdir` to create it before the copy.

![firefox_41elo1mLit](https://github.com/user-attachments/assets/8f1e004b-8e85-43fd-8d1a-7b0a1206984e)
