### PR TITLE
fix: bastion image rendering + typos

### DIFF
--- a/Linux-Labs/203-updating-golden-image/step3/text.md
+++ b/Linux-Labs/203-updating-golden-image/step3/text.md
@@ -27,7 +27,7 @@ dpkg -l | grep -i bzip2
 which bzip2
 ```{{exec}}
 
-Is bzip2 installed on your system? Can you find the executible?
+Is bzip2 installed on your system? Can you find the executable?
 
 Remove the unwanted packages
 

--- a/Linux-Labs/204-building-a-chroot-jail/step1/text.md
+++ b/Linux-Labs/204-building-a-chroot-jail/step1/text.md
@@ -32,7 +32,7 @@ ls -l /var/chroot
 
 What directories do you see? Is there anything about these directories that you know about that would make sense to give a user?
 
-Move in the minimum executibles for chroot to work properly.
+Move in the minimum executables for chroot to work properly.
 
 ```plain
 cp /usr/bin/bash /var/chroot/bin/bash

--- a/Linux-Labs/209-OS_STIG_Remediation/step2/text.md
+++ b/Linux-Labs/209-OS_STIG_Remediation/step2/text.md
@@ -22,7 +22,7 @@ Verify the enforce.sh file is correct.
 more enforce.sh
 ```{{exec}}
 
-Make the enforce.sh script executible.
+Make the enforce.sh script executable.
 
 ```plain
 chmod 755 enforce.sh

--- a/Linux-Labs/210-building-a-bastion-host/finish.md
+++ b/Linux-Labs/210-building-a-bastion-host/finish.md
@@ -5,6 +5,6 @@ You tested and verified that you were able to pass the user through to the far s
 
 Reflect on how your understanding of this topic reflects the image here.
 
-![bastion](../assets/bastion.png)
+![bastion](assets/bastion.png)
 
 What do you need to go learn more about or spend more time with now to be more effective?

--- a/Linux-Labs/210-building-a-bastion-host/step1/text.md
+++ b/Linux-Labs/210-building-a-bastion-host/step1/text.md
@@ -40,7 +40,7 @@ ls -l /var/chroot
 
 What directories do you see? Is there anything about these directories that you know about that would make sense to give a user?
 
-Move in the minimum executibles for chroot to work properly.
+Move in the minimum executables for chroot to work properly.
 
 ```plain
 cp /usr/bin/bash /var/chroot/bin/bash


### PR DESCRIPTION
New lab was great!
Minor issue on final page where the bastion image wasn't rendering properly:
![image](https://github.com/user-attachments/assets/cad94a74-6d4b-4042-a519-b526210eadb8)

PR fixes the pathing level so that it will render properly and some minor typo fixes as well.

Again, fun lab -- and an Ansible version of this setup would be neat too ;) 