### PR TITLE
fix: Typo on 'cat authorized_keys'

### DIFF
--- a/Linux-Labs/212-public-private-keys-with-ssh/step2/text.md
+++ b/Linux-Labs/212-public-private-keys-with-ssh/step2/text.md
@@ -69,7 +69,7 @@ What is the name of the file in .ssh directory?
 What permissions do you see on the file?
 
 ```plain
-cat authorized_key
+cat authorized_keys
 ```{{exec}}
 
 What was pushed into authorized keys?


### PR DESCRIPTION
The command was just missing an 's' at the end, causing it to not be able to be executed when clicked on. Just added the 's'.