### PR TITLE
Updated verify.sh Lab03/step2 to fix validation fail

### DIFF
--- a/Linux-Labs/03-checking-disk-and-mount-information/step2/verify.sh
+++ b/Linux-Labs/03-checking-disk-and-mount-information/step2/verify.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-grep 1 /root/disks
-grep 3 /root/partitions
+grep /dev/vda1 /root/fstype
+grep /etc/fstab /root/mountinfo


### PR DESCRIPTION
I was running through your labs after joining the ProLUG. Partially running through the intro stuff as a refresher and partially to learn new stuff I have not used before. While running through the 03-checking-disk-and-mount-information I got to step 2 and it was failing to validate and would not progress to step 3. 

I did some digging, after reading on your discord, that maybe I can help out and get some github practice. Poking around found how this verify.sh works. 

It looks like the check here in verify.sh is maybe an old copy of step 1 verify.sh, it is expecting there to be 3 partitions number echoed in /root/partitions. Step 1 puts a '4' in the /root/partitions file. If the step 2 verify.sh was grep 4 it would still validate, as that file is still on the Linux instance. 

So instead of just updating it to 'grep 4 /root/partitions' I decided it was probably more in line to grep check for the two files that are made and the content in them from step 2 instructions. 