### PR TITLE
fix: Change links to point to new site

### DIFF
--- a/Automation-Labs/Unit1_Tools/step1/text.md
+++ b/Automation-Labs/Unit1_Tools/step1/text.md
@@ -1,6 +1,6 @@
 ### Lab Activities
 
-This lab is designed as part of a larger set of instruction that is free from the Professional Linux Users Group (ProLUG). The lab book for this course can be found here: https://professionallinuxusersgroup.github.io/pcae/unitindex.html
+This lab is designed as part of a larger set of instruction that is free from the Professional Linux Users Group (ProLUG). The lab book for this course can be found here: https://professionallinuxusersgroup.github.io/course-books/pcae/unitindex
 
 You have found yourself in a bash shell. Ensure that you can execute simple commands and interact with your environment.
 

--- a/Automation-Labs/Unit2_Interacting_with_OS/step1/text.md
+++ b/Automation-Labs/Unit2_Interacting_with_OS/step1/text.md
@@ -1,6 +1,6 @@
 ### Lab Activities
 
-This lab is designed as part of a larger set of instruction that is free from the Professional Linux Users Group (ProLUG). The lab book for this course can be found here: https://professionallinuxusersgroup.github.io/pcae/unitindex.html
+This lab is designed as part of a larger set of instruction that is free from the Professional Linux Users Group (ProLUG). The lab book for this course can be found here: https://professionallinuxusersgroup.github.io/course-books/pcae/unitindex
 
 You have found yourself in a bash shell. Bash natively interacts with the Linux OS via built-in tools, and native tools.
 


### PR DESCRIPTION
These links were pointing to the older mdBook version of the site, which is not currently being worked on.