### PR TITLE
Add lab 112: Grafana Alloy telemetry agent on Ubuntu

### DIFF
--- a/Linux-Labs/112-grafana-alloy-telemetry-agent/README.md
+++ b/Linux-Labs/112-grafana-alloy-telemetry-agent/README.md
@@ -1,0 +1,24 @@
+# Grafana Alloy lab
+
+**Platform:** Ubuntu
+
+## KillerCoda `/answers` convention
+
+Steps reference **`/answers/`** on the lab host. That path is defined in `index.json` under `assets` - each file in `assets/` is copied to `/answers` when the scenario starts. Learners copy from `/answers` into `/etc/...` during the lab. See **`intro.md`** for the full explanation shown to students.
+
+## Contents
+
+Each step includes **explainer sections** (what / why / what to expect) before the collapsible solution commands.
+
+| Step | Topic |
+|------|--------|
+| 1 | Grafana + Loki (APT / binaries on Ubuntu) |
+| 2 | Prometheus with remote-write receiver |
+| 3 | Install Alloy from Grafana APT repo |
+| 4 | `/etc/alloy/config.alloy` - metrics + logs |
+| 5 | Verify in Grafana |
+
+## Ubuntu log paths
+
+- `/var/log/syslog`, `/var/log/auth.log` (not RHEL `/var/log/secure`)
+- `systemd-journal` group membership for the `alloy` user

--- a/Linux-Labs/112-grafana-alloy-telemetry-agent/assets/config.alloy
+++ b/Linux-Labs/112-grafana-alloy-telemetry-agent/assets/config.alloy
@@ -1,0 +1,42 @@
+// Grafana Alloy - Ubuntu lab (localhost backends, manual install)
+
+prometheus.exporter.unix "localhost" {}
+
+prometheus.scrape "local_metrics" {
+  targets    = prometheus.exporter.unix.localhost.targets
+  forward_to = [prometheus.remote_write.prom_server.receiver]
+}
+
+prometheus.remote_write "prom_server" {
+  endpoint {
+    url = "http://127.0.0.1:9090/api/v1/write"
+  }
+}
+
+loki.source.journal "system_logs" {
+  forward_to = [loki.write.loki_server.receiver]
+  labels = {
+    job      = "systemd-journal",
+    hostname = "lab-host",
+  }
+}
+
+loki.source.file "syslog_files" {
+  targets = [
+    {
+      __path__ = "/var/log/syslog",
+      job      = "syslog",
+    },
+    {
+      __path__ = "/var/log/auth.log",
+      job      = "auth",
+    },
+  ]
+  forward_to = [loki.write.loki_server.receiver]
+}
+
+loki.write "loki_server" {
+  endpoint {
+    url = "http://127.0.0.1:3100/loki/api/v1/push"
+  }
+}

--- a/Linux-Labs/112-grafana-alloy-telemetry-agent/assets/loki-local-config.yaml
+++ b/Linux-Labs/112-grafana-alloy-telemetry-agent/assets/loki-local-config.yaml
@@ -1,0 +1,64 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: debug
+  grpc_server_max_concurrent_streams: 1000
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /tmp/loki
+  storage:
+    filesystem:
+      chunks_directory: /tmp/loki/chunks
+      rules_directory: /tmp/loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+#ingester_rf1:
+#  enabled: false
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+#pattern_ingester:
+#  enabled: true
+#  metric_aggregation:
+#    enabled: true
+#    log_push_observations: true
+
+#ruler:
+#  alertmanager_url: http://localhost:9093
+
+#frontend:
+#  encoding: protobuf
+
+# By default, Loki will send anonymous, but uniquely-identifiable usage and configuration
+# analytics to Grafana Labs. These statistics are sent to https://stats.grafana.org/
+#
+# Statistics help us better understand how Loki is used, and they show us performance
+# levels for most users. This helps us prioritize features and documentation.
+# For more information on what's sent, look at
+# https://github.com/grafana/loki/blob/main/pkg/analytics/stats.go
+# Refer to the buildReport method to see what goes into a report.
+##
+# If you would like to disable reporting, uncomment the following lines:
+analytics:
+  reporting_enabled: false

--- a/Linux-Labs/112-grafana-alloy-telemetry-agent/assets/loki.service
+++ b/Linux-Labs/112-grafana-alloy-telemetry-agent/assets/loki.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Loki Startup
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/opt/loki/loki-linux-amd64 -config.file=/opt/loki/loki-local-config.yaml
+
+[Install]
+WantedBy=default.target

--- a/Linux-Labs/112-grafana-alloy-telemetry-agent/assets/prometheus.service
+++ b/Linux-Labs/112-grafana-alloy-telemetry-agent/assets/prometheus.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Prometheus
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=prometheus
+Group=prometheus
+Type=simple
+ExecStart=/usr/bin/prometheus \
+  --config.file=/etc/prometheus/prometheus.yml \
+  --storage.tsdb.path=/var/lib/prometheus/ \
+  --web.enable-remote-write-receiver
+
+[Install]
+WantedBy=multi-user.target

--- a/Linux-Labs/112-grafana-alloy-telemetry-agent/assets/prometheus.yml
+++ b/Linux-Labs/112-grafana-alloy-telemetry-agent/assets/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]

--- a/Linux-Labs/112-grafana-alloy-telemetry-agent/finish.md
+++ b/Linux-Labs/112-grafana-alloy-telemetry-agent/finish.md
@@ -1,0 +1,39 @@
+## Look at you, learning all the Linux!
+
+On a single **Ubuntu** host you built a working observability stack:
+
+- **Grafana** for exploration and dashboards  
+- **Prometheus** receiving metrics pushed by Alloy  
+- **Loki** receiving logs pushed by Alloy  
+- **Alloy** as the one agent collecting and forwarding everything  
+
+That is the same *architecture* many production environments use - you just assembled it manually so you know what each file and service actually does.
+
+<br>
+
+## Concepts worth remembering
+
+| Idea | Takeaway |
+|------|----------|
+| **Push vs scrape** | Alloy *pushes* metrics; classic Node Exporter setups are *scraped* |
+| **River config** | Alloy pipelines are declared in `config.alloy`, not in Prometheus YAML |
+| **Ubuntu logs** | `auth.log` + `syslog` + journal - paths differ on RHEL (`secure` instead of `auth.log`) |
+| **Permissions** | `alloy` needs `systemd-journal` group membership for journal logs |
+
+<br>
+
+## Where to go from here
+
+- Add labels (`hostname`, `env`, `role`) in `config.alloy` for easier filtering  
+- Point remote_write and `loki.write` at remote servers instead of `127.0.0.1`  
+- Explore OTLP traces or eBPF profiling in Alloy docs when you are ready  
+
+Thank you for working through the stack step by step.
+
+
+---
+
+This lab was contributed by ProLUG member Shane Dugas (Zorgul)
+
+Join ProLUG on [Discord](https://discord.com/invite/m6VPPD9usw).
+

--- a/Linux-Labs/112-grafana-alloy-telemetry-agent/foreground.sh
+++ b/Linux-Labs/112-grafana-alloy-telemetry-agent/foreground.sh
@@ -1,0 +1,3 @@
+echo "Installing scenario..."
+while [ ! -f /tmp/finished ]; do sleep 1; done
+echo DONE

--- a/Linux-Labs/112-grafana-alloy-telemetry-agent/index.json
+++ b/Linux-Labs/112-grafana-alloy-telemetry-agent/index.json
@@ -1,0 +1,53 @@
+{
+  "title": "Let's do Linux Configurations",
+  "description": "Grafana Alloy on Ubuntu - manual metrics and logs with Prometheus and Loki",
+  "details": {
+    "intro": {
+      "text": "intro.md",
+      "foreground": "foreground.sh",
+      "background": "setup.sh"
+    },
+    "steps": [
+      {
+        "title": "Install and configure Grafana and Loki",
+        "text": "step1/text.md",
+        "verify": "step1/verify.sh"
+      },
+      {
+        "title": "Install and configure Prometheus",
+        "text": "step2/text.md",
+        "verify": "step2/verify.sh"
+      },
+      {
+        "title": "Install Grafana Alloy",
+        "text": "step3/text.md",
+        "verify": "step3/verify.sh"
+      },
+      {
+        "title": "Configure Alloy for metrics and logs",
+        "text": "step4/text.md",
+        "verify": "step4/verify.sh"
+      },
+      {
+        "title": "Verify telemetry in Grafana",
+        "text": "step5/text.md",
+        "verify": "step5/verify.sh"
+      }
+    ],
+    "assets": {
+      "host01": [
+        { "file": "loki.service", "target": "/answers" },
+        { "file": "loki-local-config.yaml", "target": "/answers" },
+        { "file": "prometheus.service", "target": "/answers" },
+        { "file": "prometheus.yml", "target": "/answers" },
+        { "file": "config.alloy", "target": "/answers" }
+      ]
+    },
+    "finish": {
+      "text": "finish.md"
+    }
+  },
+  "backend": {
+    "imageid": "kubernetes-kubeadm-2nodes"
+  }
+}

--- a/Linux-Labs/112-grafana-alloy-telemetry-agent/intro.md
+++ b/Linux-Labs/112-grafana-alloy-telemetry-agent/intro.md
@@ -1,0 +1,57 @@
+Welcome.
+
+You are about to build a **complete observability stack on one Ubuntu machine** - by hand, from the terminal. No Ansible, no automation: just packages, config files, and `systemctl`.
+
+<br>
+
+## The old way vs Alloy
+
+| Task | Older approach (separate tools) | This lab (Alloy) |
+|------|--------------------------------|------------------|
+| Host metrics | Node Exporter + Prometheus scrape | Alloy `prometheus.exporter.unix` + remote write |
+| Logs | Promtail → Loki | Alloy `loki.source.*` → Loki |
+| Config files | Multiple formats | One `config.alloy` (River syntax) |
+
+<br>
+
+## Lab roadmap (5 steps)
+
+1. **Grafana + Loki** - UI and log storage  
+2. **Prometheus** - metric storage (with remote-write receiver for Alloy)  
+3. **Install Alloy** - package and permissions  
+4. **Configure Alloy** - wire metrics and logs in `config.alloy`  
+5. **Verify in Grafana** - prove data flows end to end  
+
+<br>
+
+## What you will use on Ubuntu
+
+- `apt` and the Grafana package repository  
+- `systemctl` for services  
+- `/etc/alloy/config.alloy` for the agent pipeline  
+- Ubuntu log paths: `/var/log/syslog`, `/var/log/auth.log`, plus the systemd journal  
+
+<br>
+
+## Lab config files and `/answers`
+
+Several steps say to copy files **from `/answers`**. That is intentional - not a normal Ubuntu system directory you create by hand.
+
+| Location | What it is |
+|----------|------------|
+| **`/answers/`** on the lab VM | Staging folder for **reference configs** (Prometheus unit file, Loki config, `config.alloy`, etc.) |
+| **`assets/`** in this lab repo | Source copies of those same files (for authors and KillerCoda) |
+| **`/etc/...`** | Where files belong **after** you copy them - real service configuration |
+
+In **KillerCoda**, the scenario copies everything from this lab’s `assets/` folder onto the VM at **`/answers`** before you start. Your job in the steps is to **`cp`** from there into the correct system paths (for example `/etc/prometheus/prometheus.yml`).
+
+**Running outside KillerCoda?** Create the folder and seed it yourself:
+
+```bash
+sudo mkdir -p /answers
+sudo cp assets/* /answers/
+```
+
+Then use the same `cp /answers/...` commands as in the steps.
+
+Take your time on step 4 - that is where the pieces connect. Steps 1-3 prepare the destinations; step 5 proves everything works.

--- a/Linux-Labs/112-grafana-alloy-telemetry-agent/setup.sh
+++ b/Linux-Labs/112-grafana-alloy-telemetry-agent/setup.sh
@@ -1,0 +1,2 @@
+apt-get update -qq && apt-get install -y -qq curl unzip wget
+touch /tmp/finished

--- a/Linux-Labs/112-grafana-alloy-telemetry-agent/step1/text.md
+++ b/Linux-Labs/112-grafana-alloy-telemetry-agent/step1/text.md
@@ -1,0 +1,90 @@
+## What you are building
+
+Before Alloy can send anything anywhere, you need **places for data to land** and **a UI to explore it**.
+
+| Component | Role in this lab |
+|-----------|------------------|
+| **Grafana** | Web UI on port **3000** - dashboards and Explore |
+| **Loki** | Log storage on port **3100** - Alloy will push logs here in step 4 |
+
+Think of this step as laying the foundation: visualization (Grafana) and log storage (Loki). Metrics storage (Prometheus) comes in step 2; the collector (Alloy) in steps 3-4.
+
+<br>
+
+## Why Grafana’s APT repository?
+
+**Grafana** and **Alloy** (later) both ship from Grafana’s official package repo. Configuring that repository once on Ubuntu keeps versions aligned and avoids hunting for random `.deb` downloads.
+
+**Loki** here is installed as a standalone binary under `/opt/loki` - a common lab pattern that matches earlier observability exercises and keeps Loki independent of the Alloy package.
+
+<br>
+
+## What to expect
+
+- Grafana will prompt you to change the default `admin` password the first time you open the UI.
+- Loki will listen on **3100**; you will not query Loki from the shell much - Grafana and Alloy talk to it over HTTP.
+- Nothing sends logs to Loki yet; that is normal until Alloy is configured.
+
+<br>
+
+### Solution
+<details>
+<summary>Solution - install Grafana and Loki on Ubuntu</summary>
+
+**1. Add the Grafana APT repository** (packages are signed; we import the key first):
+
+```plain
+apt install -y apt-transport-https software-properties-common wget
+```{{exec}}
+
+```plain
+wget -q -O /usr/share/keyrings/grafana.key https://apt.grafana.com/gpg.key
+```{{exec}}
+
+```plain
+echo "deb [signed-by=/usr/share/keyrings/grafana.key] https://apt.grafana.com stable main" | tee /etc/apt/sources.list.d/grafana.list
+```{{exec}}
+
+**2. Install and start Grafana:**
+
+```plain
+apt update
+apt install -y grafana
+```{{exec}}
+
+```plain
+systemctl daemon-reload
+systemctl enable grafana-server --now
+systemctl status grafana-server --no-pager
+ss -ntulp | grep 3000
+```{{exec}}
+
+Open Grafana in the browser (port **3000**). Sign in with `admin` / `admin` and set a new password when asked.
+
+{{TRAFFIC_HOST1_3000}}
+
+**3. Install Loki** - binary under `/opt/loki`; copy lab configs from **`/answers`** (see intro - pre-staged reference files):
+
+```plain
+mkdir -p /opt/loki
+cd /opt/loki
+```{{exec}}
+
+```plain
+curl -O -L "https://github.com/grafana/loki/releases/download/v2.9.7/loki-linux-amd64.zip"
+unzip -o loki-linux-amd64.zip
+chmod a+x loki-linux-amd64
+```{{exec}}
+
+```plain
+cp /answers/loki-local-config.yaml /opt/loki/
+cp /answers/loki.service /etc/systemd/system/loki.service
+systemctl daemon-reload
+systemctl enable loki.service --now
+systemctl status loki.service --no-pager
+ss -ntulp | grep 3100
+```{{exec}}
+
+**Checkpoint:** Both `grafana-server` and `loki.service` should be **active**. Port **3000** (Grafana) and **3100** (Loki) should appear in `ss` output.
+
+</details>

--- a/Linux-Labs/112-grafana-alloy-telemetry-agent/step1/verify.sh
+++ b/Linux-Labs/112-grafana-alloy-telemetry-agent/step1/verify.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+systemctl is-active grafana-server && systemctl is-active loki.service

--- a/Linux-Labs/112-grafana-alloy-telemetry-agent/step2/text.md
+++ b/Linux-Labs/112-grafana-alloy-telemetry-agent/step2/text.md
@@ -1,0 +1,74 @@
+## What you are building
+
+**Prometheus** is a time-series database for **metrics** (CPU, memory, disk, and so on). In older labs you might have installed **Node Exporter** and let Prometheus *scrape* it.
+
+This lab uses a different pattern:
+
+```
+Alloy (on this host)  --remote write-->  Prometheus (stores metrics)
+```
+
+Alloy runs a built-in **unix exporter** (similar data to Node Exporter) and **pushes** samples to Prometheus. Prometheus must accept those pushes.
+
+<br>
+
+## Why enable the remote-write receiver?
+
+By default Prometheus only **pulls** metrics from scrape targets. Alloy **pushes** via HTTP to:
+
+`http://127.0.0.1:9090/api/v1/write`
+
+The flag **`--web.enable-remote-write-receiver`** on the Prometheus service turns that endpoint on. Without it, Alloy’s metric pipeline would fail silently or error in the Alloy logs.
+
+<br>
+
+## What to expect
+
+- Prometheus listens on **9090**.
+- The bundled `prometheus.yml` only scrapes Prometheus itself for this lab - that is fine. Host metrics will arrive via Alloy remote write, not scrape configs.
+- You are not installing Node Exporter in this lab.
+
+<br>
+
+### Solution
+<details>
+<summary>Solution - install Prometheus with remote write enabled</summary>
+
+**1. Create a dedicated user and directories** (Prometheus should not run as root):
+
+```plain
+useradd --no-create-home prometheus 2>/dev/null || true
+mkdir -p /var/lib/prometheus /etc/prometheus
+```{{exec}}
+
+**2. Download and install the Prometheus binary:**
+
+```plain
+wget -q https://github.com/prometheus/prometheus/releases/download/v2.42.0-rc.0/prometheus-2.42.0-rc.0.linux-amd64.tar.gz -P /tmp
+tar xzf /tmp/prometheus-2.42.0-rc.0.linux-amd64.tar.gz -C /tmp
+cp /tmp/prometheus-2.42.0-rc.0.linux-amd64/prometheus /usr/bin/prometheus
+chown -R prometheus:prometheus /var/lib/prometheus
+```{{exec}}
+
+**3. Install lab config and systemd unit** - copy from **`/answers`** into `/etc` (see intro; files were staged when the scenario started):
+
+Look at the service file - confirm you see **`--web.enable-remote-write-receiver`**:
+
+```plain
+cp /answers/prometheus.yml /etc/prometheus/prometheus.yml
+cp /answers/prometheus.service /etc/systemd/system/prometheus.service
+cat /etc/systemd/system/prometheus.service
+```{{exec}}
+
+**4. Start Prometheus:**
+
+```plain
+systemctl daemon-reload
+systemctl enable prometheus --now
+systemctl status prometheus --no-pager
+ss -ntulp | grep 9090
+```{{exec}}
+
+**Checkpoint:** `prometheus` service is **active** and port **9090** is listening. You can also visit `http://127.0.0.1:9090` in the lab environment and see the Prometheus UI (optional).
+
+</details>

--- a/Linux-Labs/112-grafana-alloy-telemetry-agent/step2/verify.sh
+++ b/Linux-Labs/112-grafana-alloy-telemetry-agent/step2/verify.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+systemctl is-active prometheus

--- a/Linux-Labs/112-grafana-alloy-telemetry-agent/step3/text.md
+++ b/Linux-Labs/112-grafana-alloy-telemetry-agent/step3/text.md
@@ -1,0 +1,59 @@
+## What you are installing
+
+**Grafana Alloy** is Grafana’s unified telemetry agent. One daemon can:
+
+- Collect **host metrics** (replacing Node Exporter for many setups)
+- Tail **log files** and read the **systemd journal** (replacing Promtail)
+- Later: receive traces, profiles, and more (not in this lab)
+
+Configuration lives in **`/etc/alloy/config.alloy`** - a River language config file, not YAML.
+
+<br>
+
+## Why install the package now but configure later?
+
+The `alloy` package ships a default config so the service *can* start on install. That default will **not** point at your Loki and Prometheus yet.
+
+In this step you only:
+
+1. Install the package from the Grafana repo (already added in step 1)
+2. Grant journal access to the `alloy` user
+3. Confirm the binary runs (`alloy --version`)
+
+Step 4 replaces `/etc/alloy/config.alloy` with the lab pipeline.
+
+<br>
+
+## Why add `alloy` to the `systemd-journal` group?
+
+On Ubuntu, reading the journal requires membership in **`systemd-journal`**. Without it, Alloy’s `loki.source.journal` block would run but fail to read journal entries - logs would be missing with errors in `journalctl -u alloy`.
+
+<br>
+
+### Solution
+<details>
+<summary>Solution - install Alloy on Ubuntu</summary>
+
+**1. Install from the Grafana APT repository:**
+
+```plain
+apt update
+apt install -y alloy
+```{{exec}}
+
+**2. Allow journal access:**
+
+```plain
+usermod -aG systemd-journal alloy
+```{{exec}}
+
+**3. Confirm the binary; enable the unit** (may not be fully healthy until step 4 - that is OK):
+
+```plain
+alloy --version
+systemctl enable alloy
+```{{exec}}
+
+**Checkpoint:** `alloy --version` prints a version string (for example `v1.16.x`). You do **not** need a running pipeline yet.
+
+</details>

--- a/Linux-Labs/112-grafana-alloy-telemetry-agent/step3/verify.sh
+++ b/Linux-Labs/112-grafana-alloy-telemetry-agent/step3/verify.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+command -v alloy >/dev/null && alloy --version | head -1

--- a/Linux-Labs/112-grafana-alloy-telemetry-agent/step4/text.md
+++ b/Linux-Labs/112-grafana-alloy-telemetry-agent/step4/text.md
@@ -1,0 +1,74 @@
+## What you are configuring
+
+This is the core of the lab. **`/etc/alloy/config.alloy`** describes a small **telemetry pipeline** on one Ubuntu host:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Grafana Alloy (this host)                              │
+│                                                         │
+│  prometheus.exporter.unix  ──►  remote_write ──► Prom   │
+│  loki.source.journal       ──┐                          │
+│  loki.source.file          ──┴──►  loki.write ──► Loki  │
+└─────────────────────────────────────────────────────────┘
+```
+
+| Block in config | What it does |
+|-----------------|--------------|
+| `prometheus.exporter.unix` | Host metrics (CPU, mem, disk, network) |
+| `prometheus.remote_write` | Sends metrics to local Prometheus `:9090` |
+| `loki.source.journal` | Systemd journal logs |
+| `loki.source.file` | `/var/log/syslog` and `/var/log/auth.log` (Ubuntu paths) |
+| `loki.write` | Pushes log streams to local Loki `:3100` |
+
+<br>
+
+## Why River / `config.alloy`?
+
+Alloy configs use **River** syntax - blocks wired by `forward_to` and `receiver` references. It looks different from Prometheus scrape YAML or Promtail YAML, but the idea is the same: **sources → processors (optional) → destinations**.
+
+Run **`alloy fmt`** before restart to catch syntax errors early.
+
+<br>
+
+## What to expect after restart
+
+- `systemctl status alloy` should show **active (running)**.
+- If the service fails, run `journalctl -u alloy -n 30` - common issues: typo in config, Loki/Prometheus not running, or wrong URL.
+- Metrics may take **15-30 seconds** to appear in Prometheus after Alloy starts.
+
+<br>
+
+### Solution
+<details>
+<summary>Solution - deploy config.alloy and start the pipeline</summary>
+
+**1. Install the lab reference config** from **`/answers`** (see intro) - read it before copying; notice the `forward_to` links:
+
+```plain
+cp /answers/config.alloy /etc/alloy/config.alloy
+cat /etc/alloy/config.alloy
+```{{exec}}
+
+**2. Validate formatting:**
+
+```plain
+alloy fmt /etc/alloy/config.alloy
+```{{exec}}
+
+**3. Restart Alloy and check status:**
+
+```plain
+systemctl restart alloy
+systemctl status alloy --no-pager
+```{{exec}}
+
+**4. Quick health check in logs and sockets:**
+
+```plain
+ss -ntulp | grep alloy
+journalctl -u alloy -n 20 --no-pager
+```{{exec}}
+
+**Checkpoint:** Alloy is **active** with no repeating crash loop in `journalctl`. Loki and Prometheus from earlier steps must still be running.
+
+</details>

--- a/Linux-Labs/112-grafana-alloy-telemetry-agent/step4/verify.sh
+++ b/Linux-Labs/112-grafana-alloy-telemetry-agent/step4/verify.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+systemctl is-active alloy

--- a/Linux-Labs/112-grafana-alloy-telemetry-agent/step5/text.md
+++ b/Linux-Labs/112-grafana-alloy-telemetry-agent/step5/text.md
@@ -1,0 +1,81 @@
+## What you are verifying
+
+Installing services is only half the story. This step proves the **full path** works:
+
+1. Alloy collected data on the Ubuntu host  
+2. Prometheus and Loki stored it  
+3. Grafana can query both backends  
+
+If any link in that chain is broken, Explore will show empty results even when `systemctl` says services are fine.
+
+<br>
+
+## Grafana data sources - what to add
+
+| Data source | URL | Stores |
+|-------------|-----|--------|
+| Prometheus | `http://127.0.0.1:9090` | Metrics from Alloy remote write |
+| Loki | `http://127.0.0.1:3100` | Logs from Alloy |
+
+You only configure these once per Grafana instance. **Save & test** should report success for each.
+
+<br>
+
+## Example queries to try
+
+**Metrics (Prometheus data source):**
+
+- `up` - general health signals  
+- `node_cpu_seconds_total` - CPU metrics from Alloy’s unix exporter (names may vary slightly by version)
+
+**Logs (Loki data source):**
+
+- `{job=~"syslog|auth|systemd-journal"}` - streams defined in your `config.alloy`
+
+After running `logger "alloy-lab-test-message"`, filter or search for `alloy-lab-test` in Explore.
+
+<br>
+
+### Solution
+<details>
+<summary>Solution - wire Grafana and confirm telemetry</summary>
+
+**1. Open Grafana:**
+
+{{TRAFFIC_HOST1_3000}}
+
+**2. Add Prometheus:** Menu → **Connections** → **Data sources** → **Add data source** → **Prometheus**  
+- URL: `http://127.0.0.1:9090`  
+- **Save & test** → should show green success  
+
+**3. Add Loki:** **Add data source** → **Loki**  
+- URL: `http://127.0.0.1:3100`  
+- **Save & test** → should show green success  
+
+**4. Explore metrics:** **Explore** → select **Prometheus** → run:
+
+```promql
+up
+```
+
+Try `node_cpu_seconds_total` if `up` returns data.
+
+**5. Explore logs:** **Explore** → select **Loki** → run:
+
+```logql
+{job=~"syslog|auth|systemd-journal"}
+```
+
+**6. Generate a test log line on Ubuntu:**
+
+```plain
+logger "alloy-lab-test-message"
+```{{exec}}
+
+Refresh the Loki query within about a minute - you should see the test message (often under syslog or journal labels).
+
+**Optional:** Import dashboard ID **13639** (community syslog dashboard) for a pre-built log view.
+
+**Checkpoint:** At least one metric series and log lines visible in Explore. If not, verify all three services: `systemctl is-active grafana-server loki prometheus alloy`.
+
+</details>

--- a/Linux-Labs/112-grafana-alloy-telemetry-agent/step5/verify.sh
+++ b/Linux-Labs/112-grafana-alloy-telemetry-agent/step5/verify.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+systemctl is-active grafana-server prometheus alloy loki.service >/dev/null \
+  && curl -sf http://127.0.0.1:9090/-/healthy >/dev/null \
+  && curl -sf http://127.0.0.1:3100/ready >/dev/null

--- a/Linux-Labs/structure.json
+++ b/Linux-Labs/structure.json
@@ -22,6 +22,7 @@
       { "path": "108-kafka-to-loki-logging" },
       { "path": "109-fail2ban-with-log-monitoring" },
       { "path": "110-fail2ban-with-metric-alerting" },
+      { "path": "112-grafana-alloy-telemetry-agent" },
       { "path": "201-attempted-user-login" },
       { "path": "202-attempted-sudo-access" },
       { "path": "203-updating-golden-image" },


### PR DESCRIPTION
Five-step KillerCoda lab: Grafana and Loki, Prometheus with remote-write receiver, Alloy install and config.alloy pipeline, then verify in Explore.

Includes /answers assets, per-step verify scripts, intro and finish pages, and maintainer README. Registers the lab in Linux-Labs/structure.json.